### PR TITLE
fixed bug when GC removes dependent buffers, due to lost references

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for ref-struct
+// Project: https://github.com/TooTallNate/ref-struct
+// Definitions by: Paul Loyd <https://github.com/loyd>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import ref = require('ref');
+
+/**
+ * This is the `constructor` of the Struct type that gets returned.
+ *
+ * Invoke it with `new` to create a new Buffer instance backing the struct.
+ * Pass it an existing Buffer instance to use that as the backing buffer.
+ * Pass in an Object containing the struct fields to auto-populate the
+ * struct with the data.
+ *
+ * @constructor
+ */
+interface StructType extends ref.Type {
+    /** Pass it an existing Buffer instance to use that as the backing buffer. */
+    new (arg: Buffer, data?: {}): any;
+    new (data?: {}): any;
+    /** Pass it an existing Buffer instance to use that as the backing buffer. */
+    (arg: Buffer, data?: {}): any;
+    (data?: {}): any;
+
+    fields: { [key: string]: { type: ref.Type } };
+
+    /**
+     * Adds a new field to the struct instance with the given name and type.
+     * Note that this function will throw an Error if any instances of the struct
+     * type have already been created, therefore this function must be called at the
+     * beginning, before any instances are created.
+     */
+    defineProperty(name: string, type: ref.Type): void;
+
+    /**
+     * Adds a new field to the struct instance with the given name and type.
+     * Note that this function will throw an Error if any instances of the struct
+     * type have already been created, therefore this function must be called at the
+     * beginning, before any instances are created.
+     */
+    defineProperty(name: string, type: string): void;
+
+    /**
+     * Custom for struct type instances.
+     * @override
+     */
+    toString(): string;
+}
+
+/** The struct type meta-constructor. */
+declare var StructType: {
+    new (fields?: object, opt?: object): StructType;
+    new (fields?: any[]): StructType;
+    (fields?: object, opt?: object): StructType;
+    (fields?: any[]): StructType;
+}
+
+export = StructType;

--- a/lib/struct.js
+++ b/lib/struct.js
@@ -169,6 +169,12 @@ function set (buffer, offset, value) {
     // optimization: copy the buffer contents directly rather
     // than going through the ref-struct constructor
     value['ref.buffer'].copy(buffer, offset, 0, this.size)
+    if (value['ref.buffer']._refs) {
+      if (!buffer._refs) {
+        buffer._refs = []
+      }
+      buffer._refs = buffer._refs.concat(value['ref.buffer']._refs)
+    }
   } else {
     if (offset > 0) {
       buffer = buffer.slice(offset)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "c++",
     "ffi"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "c++",
     "ffi"
   ],
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
@@ -18,16 +18,16 @@
   "main": "./lib/struct.js",
   "license": "MIT",
   "scripts": {
-    "test": "node-gyp rebuild --directory test && mocha -gc --reporter spec"
+    "test": "node-gyp rebuild --directory test && mocha -gc-global --expose-gc --reporter spec"
   },
   "dependencies": {
-    "debug": "2",
-    "ref": "1"
+    "debug": "4",
+    "ref": "lxe/ref#node-12"
   },
   "devDependencies": {
-    "bindings": "~1.2.0",
+    "bindings": "~1.5.0",
     "nan": "2",
     "mocha": "*",
-    "ref-array": "~1.1.2"
+    "ref-array": "lxe/ref-array#node-12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "test": "node-gyp rebuild --directory test && mocha -gc-global --expose-gc --reporter spec"
   },
   "dependencies": {
-    "debug": "4",
-    "ref": "lxe/ref#node-12"
+    "debug": "4"
+  },
+  "peerDependencies": {
+    "ref": "*",
+    "ref-array": "*"
   },
   "devDependencies": {
     "bindings": "~1.5.0",
     "nan": "2",
-    "mocha": "*",
-    "ref-array": "lxe/ref-array#node-12"
+    "mocha": "*"
   }
 }


### PR DESCRIPTION
Working online reproduction that shows the problem: https://repl.it/repls/FarflungTallInterfacestandard